### PR TITLE
fix: disable remove external routes by Felix

### DIFF
--- a/docs/deployments/free5gc-with-bgp/Makefile
+++ b/docs/deployments/free5gc-with-bgp/Makefile
@@ -16,6 +16,7 @@ free5gc:
 calico:
 	kubectl apply -f $(HELM_VALUES_DIR)/../manifests/calico-pools.yaml
 	kubectl apply -f $(HELM_VALUES_DIR)/../manifests/calico-bgp.yaml
+	kubectl patch felixconfiguration default --type='merge' -p '{"spec":{"removeExternalRoutes":false}}'
 
 upf:
 	helm $(HELM_ACTION) \

--- a/docs/deployments/free5gc-with-bgp/README.md
+++ b/docs/deployments/free5gc-with-bgp/README.md
@@ -40,7 +40,7 @@ Be careful, this document work in progress
 
     close port forward with `Ctrl + C`
 
-1. configure calico BGP settings. Here, we configure Calico BGP peer and create Calico IP Pool (for NAT)
+1. configure calico BGP settings. Here, we configure Calico BGP peer, create Calico IP Pool (for NAT) and configure Felix for save external routes (recevied by BGP from eUPF BIRD)
 
     `make calico`
 

--- a/docs/deployments/open5gs-with-bgp-and-slices/Makefile
+++ b/docs/deployments/open5gs-with-bgp-and-slices/Makefile
@@ -39,6 +39,7 @@ smf2:
 calico:
 	kubectl apply -f $(HELM_VALUES_DIR)/../manifests/calico-pools.yaml
 	kubectl apply -f $(HELM_VALUES_DIR)/../manifests/calico-bgp.yaml
+	kubectl patch felixconfiguration default --type='merge' -p '{"spec":{"removeExternalRoutes":false}}'
 
 upf:
 	helm $(HELM_ACTION) \

--- a/docs/deployments/open5gs-with-bgp-and-slices/README.md
+++ b/docs/deployments/open5gs-with-bgp-and-slices/README.md
@@ -27,7 +27,7 @@
 
     `make upf2`
 
-3. configure calico BGP settings
+3. configure calico BGP settings. Here, we configure Calico BGP peer, create Calico IP Pool (for NAT) and configure Felix for save external routes (recevied by BGP from eUPF BIRD)
 
     `make calico`
 

--- a/docs/deployments/open5gs-with-bgp/Makefile
+++ b/docs/deployments/open5gs-with-bgp/Makefile
@@ -27,6 +27,7 @@ smf:
 calico:
 	kubectl apply -f $(HELM_VALUES_DIR)/../manifests/calico-pools.yaml
 	kubectl apply -f $(HELM_VALUES_DIR)/../manifests/calico-bgp.yaml
+	kubectl patch felixconfiguration default --type='merge' -p '{"spec":{"removeExternalRoutes":false}}'
 
 upf:
 	helm $(HELM_ACTION) \

--- a/docs/deployments/open5gs-with-bgp/README.md
+++ b/docs/deployments/open5gs-with-bgp/README.md
@@ -23,7 +23,7 @@
 
     `make upf`
 
-2. configure calico BGP settings. Here, we configure Calico BGP peer and create Calico IP Pool (for NAT)
+2. configure calico BGP settings. Here, we configure Calico BGP peer, create Calico IP Pool (for NAT) and configure Felix for save external routes (recevied by BGP from eUPF BIRD)
 
     `make calico`
 


### PR DESCRIPTION
felix/route_table.go 939: Remove old route dest=10.11.0.0/16 ifaceName="cali3fe0cc46b74" ifaceRegex="^cali.*" ipVersion=0x4 routeProblems=[]string{"unexpected route", "incorrect protocol", "incorrect gateway"} tableIndex=0

for fix this error, we need change felix configuration