### PR TITLE
fix: ignore SDF Filter with empty Flow Description

### DIFF
--- a/cmd/core/pdr_creation_context.go
+++ b/cmd/core/pdr_creation_context.go
@@ -43,7 +43,9 @@ func (pdrContext *PDRCreationContext) extractPDR(pdr *ie.IE, spdrInfo *SPDRInfo)
 	}
 
 	if sdfFilter, err := pdr.SDFFilter(); err == nil {
-		if sdfFilterParsed, err := ParseSdfFilter(sdfFilter.FlowDescription); err == nil {
+		if sdfFilter.FlowDescription == "" {
+			log.Warn().Msgf("SDFFilter is empty")
+		} else if sdfFilterParsed, err := ParseSdfFilter(sdfFilter.FlowDescription); err == nil {
 			spdrInfo.PdrInfo.SdfFilter = &sdfFilterParsed
 		} else {
 			log.Error().Msgf("SDFFilter err: %v", err)

--- a/cmd/core/pdr_creation_context_test.go
+++ b/cmd/core/pdr_creation_context_test.go
@@ -44,6 +44,26 @@ func TestPDRCreationContext_extractPDR(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "emptyFlowDescriptionAndFilterID",
+			fields: fields{
+				Session:         nil,
+				ResourceManager: nil,
+				//TEEIDCache: nil,
+			},
+			args: args{
+				pdr: ie.NewCreatePDR(
+					ie.NewPDRID(2),
+					ie.NewPDI(
+						ie.NewSourceInterface(ie.SrcInterfaceCore),
+						ie.NewUEIPAddress(2, "192.168.0.1", "", 0, 0),
+						ie.NewSDFFilter("", "", "", "", 4096),
+					),
+				),
+				spdrInfo: &SPDRInfo{},
+			},
+			wantErr: false,
+		},
+		{
 			name: "invalidFlowDescription",
 			fields: fields{
 				Session:         nil,
@@ -56,7 +76,7 @@ func TestPDRCreationContext_extractPDR(t *testing.T) {
 					ie.NewPDI(
 						ie.NewSourceInterface(ie.SrcInterfaceCore),
 						ie.NewUEIPAddress(2, "192.168.0.1", "", 0, 0),
-						ie.NewSDFFilter("blablabla", "", "", "", 0),
+						ie.NewSDFFilter("123", "", "", "", 4096),
 					),
 				),
 				spdrInfo: &SPDRInfo{},

--- a/cmd/core/pdr_creation_context_test.go
+++ b/cmd/core/pdr_creation_context_test.go
@@ -1,0 +1,99 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/edgecomllc/eupf/cmd/core/service"
+	"github.com/wmnsk/go-pfcp/ie"
+)
+
+func TestPDRCreationContext_extractPDR(t *testing.T) {
+	type fields struct {
+		Session         *Session
+		ResourceManager *service.ResourceManager
+		TEIDCache       map[uint8]uint32
+	}
+	type args struct {
+		pdr      *ie.IE
+		spdrInfo *SPDRInfo
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "emptyFlowDescription",
+			fields: fields{
+				Session:         nil,
+				ResourceManager: nil,
+				//TEEIDCache: nil,
+			},
+			args: args{
+				pdr: ie.NewCreatePDR(
+					ie.NewPDRID(2),
+					ie.NewPDI(
+						ie.NewSourceInterface(ie.SrcInterfaceCore),
+						ie.NewUEIPAddress(2, "192.168.0.1", "", 0, 0),
+						ie.NewSDFFilter("", "ttc", "", "", 0),
+					),
+				),
+				spdrInfo: &SPDRInfo{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalidFlowDescription",
+			fields: fields{
+				Session:         nil,
+				ResourceManager: nil,
+				//TEEIDCache: nil,
+			},
+			args: args{
+				pdr: ie.NewCreatePDR(
+					ie.NewPDRID(2),
+					ie.NewPDI(
+						ie.NewSourceInterface(ie.SrcInterfaceCore),
+						ie.NewUEIPAddress(2, "192.168.0.1", "", 0, 0),
+						ie.NewSDFFilter("blablabla", "", "", "", 0),
+					),
+				),
+				spdrInfo: &SPDRInfo{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "validFlowDescription",
+			fields: fields{
+				Session:         nil,
+				ResourceManager: nil,
+				//TEEIDCache: nil,
+			},
+			args: args{
+				pdr: ie.NewCreatePDR(
+					ie.NewPDRID(2),
+					ie.NewPDI(
+						ie.NewSourceInterface(ie.SrcInterfaceCore),
+						ie.NewUEIPAddress(2, "192.168.0.1", "", 0, 0),
+						ie.NewSDFFilter("permit out ip from 10.62.0.1 to 8.8.8.8/32", "", "", "", 0),
+					),
+				),
+				spdrInfo: &SPDRInfo{},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pdrContext := &PDRCreationContext{
+				Session:         tt.fields.Session,
+				ResourceManager: tt.fields.ResourceManager,
+				TEIDCache:       tt.fields.TEIDCache,
+			}
+			if err := pdrContext.extractPDR(tt.args.pdr, tt.args.spdrInfo); (err != nil) != tt.wantErr {
+				t.Errorf("PDRCreationContext.extractPDR() error: %v, expected error: %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/core/sdf_filter_parser.go
+++ b/cmd/core/sdf_filter_parser.go
@@ -17,7 +17,7 @@ func ParseSdfFilter(flowDescription string) (ebpf.SdfFilter, error) {
 	var err error
 
 	match := re.FindStringSubmatch(flowDescription)
-	log.Printf("Matched groups: %v\n", match)
+	log.Printf("Matched groups: %+q\n", match)
 	if len(match) == 0 {
 		return ebpf.SdfFilter{}, fmt.Errorf("SDF Filter: bad formatting. Should be compatible with regexp: %s", re.String())
 	}

--- a/cmd/core/sdf_filter_parser_test.go
+++ b/cmd/core/sdf_filter_parser_test.go
@@ -27,6 +27,9 @@ func TestSdfFilterParseValid(t *testing.T) {
 		{FlowDescription: "permit out ip from 10.60.0.0/16 to any", Protocol: 1,
 			SrcType: 1, SrcAddress: "10.60.0.0", SrcMask: "ffff0000", SrcPortLower: 0, SrcPortUpper: 65535,
 			DstType: 0, DstAddress: "<nil>", DstMask: "<nil>", DstPortLower: 0, DstPortUpper: 65535},
+		{FlowDescription: "permit out ip from any to any", Protocol: 1,
+			SrcType: 0, SrcAddress: "<nil>", SrcMask: "<nil>", SrcPortLower: 0, SrcPortUpper: 65535,
+			DstType: 0, DstAddress: "<nil>", DstMask: "<nil>", DstPortLower: 0, DstPortUpper: 65535},
 	}
 
 	for i := 0; i < len(fds); i++ {


### PR DESCRIPTION
Actually, initial issue was caused not only empty SDF Filter Description, but also ignoring SDF Filter ID reference. It's possible not to set specific flow description, but reference previously configured SDF filter.

This PR just only allows to ignore empty SDF filter in order to apply PDR. SDF filter ID will be supported in the separate ticket.