### PR TITLE
fix deploy open5gs-compose #547 

### DIFF
--- a/docs/deployments/open5gs-compose/README.md
+++ b/docs/deployments/open5gs-compose/README.md
@@ -15,14 +15,28 @@ docker network create \
     --driver=bridge \
     --subnet=172.20.0.0/24 \
     --gateway=172.20.0.1 \
+    -o "com.docker.network.bridge.name"="br-open5gs-main" \
     open5gs-main
+sudo ethtool -K br-open5gs-main tx off
 ```
 
+<details><summary><i> Here we turn off tx offload to avoid TCP checksum error in internal packets for iperf tests.</summary>
+<p>
+
+Apparently, checksum offloading is enabled by default and the kernel postpones csum calculation until the last moment, expecting csum to be calculated in the driver when the packet is sent. But we have a virtual environment and the packet eventually goes to the GTP tunnel on UPF. Obviously, this is the reason why csum is not calculated correctly.
+
+However, if we disable offloading, the checksum is calculated immediately on iperf and everything works.
+</p>
+</details> 
+
+<!---
 # configure firewall
 
 `bash fw.sh`
+--><br>
+# To run multiple iperf servers, use this command
 
-# for run multiple iperf servers, use this command
+`sudo apt install iperf3`
 
 `for i in $(seq 5201 5208); do (iperf3 -s -p $i &) ; done`
 
@@ -67,3 +81,5 @@ when test ended, you can see reports in directory `.deploy/docker/local-data/ipe
 # stop and remove all containers
 
 `make clean`
+
+`docker network rm open5gs-main`

--- a/docs/deployments/open5gs-compose/docker-compose.ue2.yaml
+++ b/docs/deployments/open5gs-compose/docker-compose.ue2.yaml
@@ -14,7 +14,7 @@ x-ue-env: &ue_env
   APN: internet
   SST: 1
   SD: "0x222222"
-  IPERF_HOST: 10.128.0.14
+  IPERF_HOST: 172.20.0.1
   IPERF_TIME: 30
 
 x-ue-service: &ue_service
@@ -36,7 +36,7 @@ services:
     environment:
       <<: *ue_env
       MSISDN: "0000000003"
-      GNB_HOSTNAME: open5gs-gnb-1
+      GNB_HOSTNAME: open5gs-compose-gnb-1
       IPERF_PORT: 5201
 
   ue2-04:
@@ -44,7 +44,7 @@ services:
     environment:
       <<: *ue_env
       MSISDN: "0000000004"
-      GNB_HOSTNAME: open5gs-gnb-2
+      GNB_HOSTNAME: open5gs-compose-gnb-2
       IPERF_PORT: 5202
 
   ue2-05:
@@ -52,7 +52,7 @@ services:
     environment:
       <<: *ue_env
       MSISDN: "0000000005"
-      GNB_HOSTNAME: open5gs-gnb-3
+      GNB_HOSTNAME: open5gs-compose-gnb-3
       IPERF_PORT: 5203
 
   ue2-06:
@@ -60,7 +60,7 @@ services:
     environment:
       <<: *ue_env
       MSISDN: "0000000006"
-      GNB_HOSTNAME: open5gs-gnb-4
+      GNB_HOSTNAME: open5gs-compose-gnb-4
       IPERF_PORT: 5204
 
   ue2-07:
@@ -68,7 +68,7 @@ services:
     environment:
       <<: *ue_env
       MSISDN: "0000000007"
-      GNB_HOSTNAME: open5gs-gnb-5
+      GNB_HOSTNAME: open5gs-compose-gnb-5
       IPERF_PORT: 5205
 
   ue2-08:
@@ -76,7 +76,7 @@ services:
     environment:
       <<: *ue_env
       MSISDN: "0000000008"
-      GNB_HOSTNAME: open5gs-gnb-6
+      GNB_HOSTNAME: open5gs-compose-gnb-6
       IPERF_PORT: 5206
 
 networks:

--- a/docs/docs-ru_ru/deployments/open5gs-compose/README.md
+++ b/docs/docs-ru_ru/deployments/open5gs-compose/README.md
@@ -25,14 +25,29 @@ docker network create \
     --driver=bridge \
     --subnet=172.20.0.0/24 \
     --gateway=172.20.0.1 \
+    -o "com.docker.network.bridge.name"="br-open5gs-main" \
     open5gs-main
+sudo ethtool -K br-open5gs-main tx off
 ```
 
+<details><summary> <i>Здесь мы отключаем tx offload чтобы не было TCP checksum error на внутренних пакетах, для тестов iperf.</summary>
+<p>
+
+Видимо дело в том, что по-умолчанию включен offloading расчета контрольных сумм и ядро до последнего откладывает вычисление csum в расчете на то, что csum посчитается в драйвере при отправке пакета. Но у нас виртуальное окружение и пакет в итоге улетает в туннель GTP на UPF. Видимо из-за этого не происходит корректного расчета csum.
+
+При этом если отключить offloading, то контрольная сумма считается сразу же на iperf и всё работает.
+
+</p>
+</details> 
+
+<!---
 # настройте правила firewall
 
 `bash fw.sh`
-
+--><br>
 # запустите iperf-сервисы
+
+`sudo apt install iperf3`
 
 `for i in $(seq 5201 5208); do (iperf3 -s -p $i &) ; done`
 
@@ -77,3 +92,5 @@ docker network create \
 # остановка и удаление всех контейнеров
 
 `make clean`
+
+`docker network rm open5gs-main`


### PR DESCRIPTION
Corrections in the manual and in docker-compose.ue2.yaml
- removed iptables flush and config
- added `sudo apt install iperf3`
- added command to turn off tx offload @ new bridge interface
- fixed env `IPERF_HOST: 172.20.0.1`
- fixed env `GNB_HOSTNAME: open5gs-compose-gnb-1`