### PR TITLE
Support Traffic Steering for Service Function Chaining

### DIFF
--- a/cmd/core/display_utils.go
+++ b/cmd/core/display_utils.go
@@ -267,6 +267,10 @@ func displayFar(sb *strings.Builder, far *ie.IE) {
 			if err == nil {
 				writeLineTabbed(sb, fmt.Sprintf("Header Enrichment: %s : %s ", headerEnrichment.HeaderFieldName, headerEnrichment.HeaderFieldValue), 3)
 			}
+			forwardingPolicyIdentifier, err := forwardingParameter.ForwardingPolicyIdentifier()
+			if err == nil {
+				writeLineTabbed(sb, fmt.Sprintf("Fordward Policy Identifier: %s ", forwardingPolicyIdentifier), 3)
+			}
 		}
 	}
 	if updateForwardingParameters, err := far.UpdateForwardingParameters(); err == nil {
@@ -288,6 +292,10 @@ func displayFar(sb *strings.Builder, far *ie.IE) {
 			headerEnrichment, err := updateForwardingParameter.HeaderEnrichment()
 			if err == nil {
 				writeLineTabbed(sb, fmt.Sprintf("Header Enrichment: %s : %s ", headerEnrichment.HeaderFieldName, headerEnrichment.HeaderFieldValue), 3)
+			}
+			forwardingPolicyIdentifier, err := updateForwardingParameter.ForwardingPolicyIdentifier()
+			if err == nil {
+				writeLineTabbed(sb, fmt.Sprintf("Fordward Policy Identifier: %s ", forwardingPolicyIdentifier), 3)
 			}
 		}
 	}

--- a/cmd/core/pfcp_session_handlers.go
+++ b/cmd/core/pfcp_session_handlers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"strconv"
 
 	"github.com/edgecomllc/eupf/cmd/ebpf"
 
@@ -478,6 +479,16 @@ func composeFarInfo(far *ie.IE, localIp net.IP, farInfo ebpf.FarInfo) (ebpf.FarI
 			if outerHeaderCreation.HasIPv6() {
 				log.Info().Msg("WARN: IPv6 not supported yet, ignoring")
 				return ebpf.FarInfo{}, fmt.Errorf("IPv6 not supported yet")
+			}
+		}
+		forwardingPolicyIndex := findIEindex(forward, 41) // IE Type Outer Header Creation
+		if forwardingPolicyIndex == -1 {
+			log.Info().Msg("WARN: No ForwardingPolicy")
+		} else {
+			forwardingPolicyIdentifier, _ := forward[forwardingPolicyIndex].ForwardingPolicyIdentifier()
+			uint64Value, err := strconv.ParseUint(forwardingPolicyIdentifier, 16, 64)
+			if err == nil {
+				farInfo.ForwardingPolicyIdentifier = uint64Value
 			}
 		}
 	}

--- a/cmd/ebpf/pdr.go
+++ b/cmd/ebpf/pdr.go
@@ -149,12 +149,13 @@ func (bpfObjects *BpfObjects) DeleteDownlinkPdrIp6(ipv6 net.IP) error {
 }
 
 type FarInfo struct {
-	Action                uint8
-	OuterHeaderCreation   uint8
-	Teid                  uint32
-	RemoteIP              uint32
-	LocalIP               uint32
-	TransportLevelMarking uint16
+	Action                     uint8
+	OuterHeaderCreation        uint8
+	Teid                       uint32
+	RemoteIP                   uint32
+	LocalIP                    uint32
+	TransportLevelMarking      uint16
+	ForwardingPolicyIdentifier uint64
 }
 
 func (f FarInfo) MarshalJSON() ([]byte, error) {
@@ -163,12 +164,13 @@ func (f FarInfo) MarshalJSON() ([]byte, error) {
 	binary.LittleEndian.PutUint32(remoteIP, f.RemoteIP)
 	binary.LittleEndian.PutUint32(localIP, f.LocalIP)
 	data := map[string]interface{}{
-		"action":                  f.Action,
-		"outer_header_creation":   f.OuterHeaderCreation,
-		"teid":                    f.Teid,
-		"remote_ip":               remoteIP.String(),
-		"local_ip":                localIP.String(),
-		"transport_level_marking": f.TransportLevelMarking,
+		"action":                       f.Action,
+		"outer_header_creation":        f.OuterHeaderCreation,
+		"teid":                         f.Teid,
+		"remote_ip":                    remoteIP.String(),
+		"local_ip":                     localIP.String(),
+		"transport_level_marking":      f.TransportLevelMarking,
+		"forwarding_policy_identifier": f.ForwardingPolicyIdentifier,
 	}
 	return json.Marshal(data)
 }

--- a/cmd/ebpf/xdp/pdr.h
+++ b/cmd/ebpf/xdp/pdr.h
@@ -114,6 +114,7 @@ struct far_info {
     __u32 localip;
     /* first octet DSCP value in the Type-of-Service, second octet shall contain the ToS/Traffic Class mask field, which shall be set to "0xFC". */
     __u16 transport_level_marking;
+    __u64 forwarding_policy_identifier;
 };
 
 /* FAR ID -> FAR */

--- a/cmd/ebpf/xdp/utils/gtp_utils.h
+++ b/cmd/ebpf/xdp/utils/gtp_utils.h
@@ -242,7 +242,7 @@ static __always_inline __u32 add_gtp_over_ip4_headers(struct packet_context *ctx
     // udp->check = cs;
 
     /* Update packet pointers */
-    context_set_ip4(ctx, (char *)(long)ctx->xdp_ctx->data, (const char *)(long)ctx->xdp_ctx->data_end, eth, ip, udp, gtp);
+    context_set_ip4(ctx, (char *)(long)ctx->xdp_ctx->data, (const char *)(long)ctx->xdp_ctx->data_end, eth, ip, udp, gtp, 0);
     return 0;
 }
 

--- a/cmd/ebpf/xdp/utils/nsh.h
+++ b/cmd/ebpf/xdp/utils/nsh.h
@@ -1,0 +1,303 @@
+#ifndef __NET_NSH_H
+#define __NET_NSH_H 1
+
+// #include <linux/skbuff.h>
+
+/*
+ * Network Service Header:
+ *  0                   1                   2                   3
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |Ver|O|U|    TTL    |   Length  |U|U|U|U|MD Type| Next Protocol |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |          Service Path Identifier (SPI)        | Service Index |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                                                               |
+ * ~               Mandatory/Optional Context Headers              ~
+ * |                                                               |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *
+ * Version: The version field is used to ensure backward compatibility
+ * going forward with future NSH specification updates.  It MUST be set
+ * to 0x0 by the sender, in this first revision of NSH.  Given the
+ * widespread implementation of existing hardware that uses the first
+ * nibble after an MPLS label stack for ECMP decision processing, this
+ * document reserves version 01b and this value MUST NOT be used in
+ * future versions of the protocol.  Please see [RFC7325] for further
+ * discussion of MPLS-related forwarding requirements.
+ *
+ * O bit: Setting this bit indicates an Operations, Administration, and
+ * Maintenance (OAM) packet.  The actual format and processing of SFC
+ * OAM packets is outside the scope of this specification (see for
+ * example [I-D.ietf-sfc-oam-framework] for one approach).
+ *
+ * The O bit MUST be set for OAM packets and MUST NOT be set for non-OAM
+ * packets.  The O bit MUST NOT be modified along the SFP.
+ *
+ * SF/SFF/SFC Proxy/Classifier implementations that do not support SFC
+ * OAM procedures SHOULD discard packets with O bit set, but MAY support
+ * a configurable parameter to enable forwarding received SFC OAM
+ * packets unmodified to the next element in the chain.  Forwarding OAM
+ * packets unmodified by SFC elements that do not support SFC OAM
+ * procedures may be acceptable for a subset of OAM functions, but can
+ * result in unexpected outcomes for others, thus it is recommended to
+ * analyze the impact of forwarding an OAM packet for all OAM functions
+ * prior to enabling this behavior.  The configurable parameter MUST be
+ * disabled by default.
+ *
+ * TTL: Indicates the maximum SFF hops for an SFP.  This field is used
+ * for service plane loop detection.  The initial TTL value SHOULD be
+ * configurable via the control plane; the configured initial value can
+ * be specific to one or more SFPs.  If no initial value is explicitly
+ * provided, the default initial TTL value of 63 MUST be used.  Each SFF
+ * involved in forwarding an NSH packet MUST decrement the TTL value by
+ * 1 prior to NSH forwarding lookup.  Decrementing by 1 from an incoming
+ * value of 0 shall result in a TTL value of 63.  The packet MUST NOT be
+ * forwarded if TTL is, after decrement, 0.
+ *
+ * All other flag fields, marked U, are unassigned and available for
+ * future use, see Section 11.2.1.  Unassigned bits MUST be set to zero
+ * upon origination, and MUST be ignored and preserved unmodified by
+ * other NSH supporting elements.  Elements which do not understand the
+ * meaning of any of these bits MUST NOT modify their actions based on
+ * those unknown bits.
+ *
+ * Length: The total length, in 4-byte words, of NSH including the Base
+ * Header, the Service Path Header, the Fixed Length Context Header or
+ * Variable Length Context Header(s).  The length MUST be 0x6 for MD
+ * Type equal to 0x1, and MUST be 0x2 or greater for MD Type equal to
+ * 0x2.  The length of the NSH header MUST be an integer multiple of 4
+ * bytes, thus variable length metadata is always padded out to a
+ * multiple of 4 bytes.
+ *
+ * MD Type: Indicates the format of NSH beyond the mandatory Base Header
+ * and the Service Path Header.  MD Type defines the format of the
+ * metadata being carried.
+ *
+ * 0x0 - This is a reserved value.  Implementations SHOULD silently
+ * discard packets with MD Type 0x0.
+ *
+ * 0x1 - This indicates that the format of the header includes a fixed
+ * length Context Header (see Figure 4 below).
+ *
+ * 0x2 - This does not mandate any headers beyond the Base Header and
+ * Service Path Header, but may contain optional variable length Context
+ * Header(s).  The semantics of the variable length Context Header(s)
+ * are not defined in this document.  The format of the optional
+ * variable length Context Headers is provided in Section 2.5.1.
+ *
+ * 0xF - This value is reserved for experimentation and testing, as per
+ * [RFC3692].  Implementations not explicitly configured to be part of
+ * an experiment SHOULD silently discard packets with MD Type 0xF.
+ *
+ * Next Protocol: indicates the protocol type of the encapsulated data.
+ * NSH does not alter the inner payload, and the semantics on the inner
+ * protocol remain unchanged due to NSH service function chaining.
+ * Please see the IANA Considerations section below, Section 11.2.5.
+ *
+ * This document defines the following Next Protocol values:
+ *
+ * 0x1: IPv4
+ * 0x2: IPv6
+ * 0x3: Ethernet
+ * 0x4: NSH
+ * 0x5: MPLS
+ * 0xFE: Experiment 1
+ * 0xFF: Experiment 2
+ *
+ * Packets with Next Protocol values not supported SHOULD be silently
+ * dropped by default, although an implementation MAY provide a
+ * configuration parameter to forward them.  Additionally, an
+ * implementation not explicitly configured for a specific experiment
+ * [RFC3692] SHOULD silently drop packets with Next Protocol values 0xFE
+ * and 0xFF.
+ *
+ * Service Path Identifier (SPI): Identifies a service path.
+ * Participating nodes MUST use this identifier for Service Function
+ * Path selection.  The initial classifier MUST set the appropriate SPI
+ * for a given classification result.
+ *
+ * Service Index (SI): Provides location within the SFP.  The initial
+ * classifier for a given SFP SHOULD set the SI to 255, however the
+ * control plane MAY configure the initial value of SI as appropriate
+ * (i.e., taking into account the length of the service function path).
+ * The Service Index MUST be decremented by a value of 1 by Service
+ * Functions or by SFC Proxy nodes after performing required services
+ * and the new decremented SI value MUST be used in the egress packet's
+ * NSH.  The initial Classifier MUST send the packet to the first SFF in
+ * the identified SFP for forwarding along an SFP.  If re-classification
+ * occurs, and that re-classification results in a new SPI, the
+ * (re)classifier is, in effect, the initial classifier for the
+ * resultant SPI.
+ *
+ * The SI is used in conjunction the with Service Path Identifier for
+ * Service Function Path Selection and for determining the next SFF/SF
+ * in the path.  The SI is also valuable when troubleshooting or
+ * reporting service paths.  Additionally, while the TTL field is the
+ * main mechanism for service plane loop detection, the SI can also be
+ * used for detecting service plane loops.
+ *
+ * When the Base Header specifies MD Type = 0x1, a Fixed Length Context
+ * Header (16-bytes) MUST be present immediately following the Service
+ * Path Header. The value of a Fixed Length Context
+ * Header that carries no metadata MUST be set to zero.
+ *
+ * When the base header specifies MD Type = 0x2, zero or more Variable
+ * Length Context Headers MAY be added, immediately following the
+ * Service Path Header (see Figure 5).  Therefore, Length = 0x2,
+ * indicates that only the Base Header followed by the Service Path
+ * Header are present.  The optional Variable Length Context Headers
+ * MUST be of an integer number of 4-bytes.  The base header Length
+ * field MUST be used to determine the offset to locate the original
+ * packet or frame for SFC nodes that require access to that
+ * information.
+ *
+ * The format of the optional variable length Context Headers
+ *
+ *  0                   1                   2                   3
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |          Metadata Class       |      Type     |U|    Length   |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                      Variable Metadata                        |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *
+ * Metadata Class (MD Class): Defines the scope of the 'Type' field to
+ * provide a hierarchical namespace.  The IANA Considerations
+ * Section 11.2.4 defines how the MD Class values can be allocated to
+ * standards bodies, vendors, and others.
+ *
+ * Type: Indicates the explicit type of metadata being carried.  The
+ * definition of the Type is the responsibility of the MD Class owner.
+ *
+ * Unassigned bit: One unassigned bit is available for future use. This
+ * bit MUST NOT be set, and MUST be ignored on receipt.
+ *
+ * Length: Indicates the length of the variable metadata, in bytes.  In
+ * case the metadata length is not an integer number of 4-byte words,
+ * the sender MUST add pad bytes immediately following the last metadata
+ * byte to extend the metadata to an integer number of 4-byte words.
+ * The receiver MUST round up the length field to the nearest 4-byte
+ * word boundary, to locate and process the next field in the packet.
+ * The receiver MUST access only those bytes in the metadata indicated
+ * by the length field (i.e., actual number of bytes) and MUST ignore
+ * the remaining bytes up to the nearest 4-byte word boundary.  The
+ * Length may be 0 or greater.
+ *
+ * A value of 0 denotes a Context Header without a Variable Metadata
+ * field.
+ *
+ * [0] https://datatracker.ietf.org/doc/draft-ietf-sfc-nsh/
+ */
+
+/**
+ * struct nsh_md1_ctx - Keeps track of NSH context data
+ * @context: NSH Contexts.
+ */
+struct nsh_md1_ctx {
+	__be32 context[4];
+};
+
+struct nsh_md2_tlv {
+	__be16 md_class;
+	__u8 type;
+	__u8 length;
+	__u8 md_value[];
+};
+
+struct nshhdr {
+	__be16 ver_flags_ttl_len;
+	__u8 mdtype;
+	__u8 np;
+	__be32 path_hdr;
+	union {
+	    struct nsh_md1_ctx md1;
+	    struct nsh_md2_tlv md2;
+	};
+};
+
+/* Masking NSH header fields. */
+#define NSH_VER_MASK       0xc000
+#define NSH_VER_SHIFT      14
+#define NSH_FLAGS_MASK     0x3000
+#define NSH_FLAGS_SHIFT    12
+#define NSH_TTL_MASK       0x0fc0
+#define NSH_TTL_SHIFT      6
+#define NSH_LEN_MASK       0x003f
+#define NSH_LEN_SHIFT      0
+
+#define NSH_MDTYPE_MASK    0x0f
+#define NSH_MDTYPE_SHIFT   0
+
+#define NSH_SPI_MASK       0xffffff00
+#define NSH_SPI_SHIFT      8
+#define NSH_SI_MASK        0x000000ff
+#define NSH_SI_SHIFT       0
+
+/* MD Type Registry. */
+#define NSH_M_TYPE1     0x01
+#define NSH_M_TYPE2     0x02
+#define NSH_M_EXP1      0xFE
+#define NSH_M_EXP2      0xFF
+
+/* NSH Base Header Length */
+#define NSH_BASE_HDR_LEN  8
+
+/* NSH MD Type 1 header Length. */
+#define NSH_M_TYPE1_LEN   24
+
+/* NSH header maximum Length. */
+#define NSH_HDR_MAX_LEN 256
+
+/* NSH context headers maximum Length. */
+#define NSH_CTX_HDRS_MAX_LEN 248
+
+static inline __u16 nsh_hdr_len(const struct nshhdr *nsh)
+{
+	return ((bpf_ntohs(nsh->ver_flags_ttl_len) & NSH_LEN_MASK)
+		>> NSH_LEN_SHIFT) << 2;
+}
+
+static inline __u8 nsh_get_ver(const struct nshhdr *nsh)
+{
+	return (bpf_ntohs(nsh->ver_flags_ttl_len) & NSH_VER_MASK)
+		>> NSH_VER_SHIFT;
+}
+
+static inline __u8 nsh_get_flags(const struct nshhdr *nsh)
+{
+	return (bpf_ntohs(nsh->ver_flags_ttl_len) & NSH_FLAGS_MASK)
+		>> NSH_FLAGS_SHIFT;
+}
+
+static inline __u8 nsh_get_ttl(const struct nshhdr *nsh)
+{
+	return (bpf_ntohs(nsh->ver_flags_ttl_len) & NSH_TTL_MASK)
+		>> NSH_TTL_SHIFT;
+}
+
+static inline void __nsh_set_xflag(struct nshhdr *nsh, __u16 xflag, __u16 xmask)
+{
+	nsh->ver_flags_ttl_len
+		= (nsh->ver_flags_ttl_len & ~bpf_htons(xmask)) | bpf_htons(xflag);
+}
+
+static inline void nsh_set_flags_and_ttl(struct nshhdr *nsh, __u8 flags, __u8 ttl)
+{
+	__nsh_set_xflag(nsh, ((flags << NSH_FLAGS_SHIFT) & NSH_FLAGS_MASK) |
+			     ((ttl << NSH_TTL_SHIFT) & NSH_TTL_MASK),
+			NSH_FLAGS_MASK | NSH_TTL_MASK);
+}
+
+static inline void nsh_set_flags_ttl_len(struct nshhdr *nsh, __u8 flags,
+					 __u8 ttl, __u8 len)
+{
+	len = len >> 2;
+	__nsh_set_xflag(nsh, ((flags << NSH_FLAGS_SHIFT) & NSH_FLAGS_MASK) |
+			     ((ttl << NSH_TTL_SHIFT) & NSH_TTL_MASK) |
+			     ((len << NSH_LEN_SHIFT) & NSH_LEN_MASK),
+			NSH_FLAGS_MASK | NSH_TTL_MASK | NSH_LEN_MASK);
+}
+
+
+#endif /* __NET_NSH_H */

--- a/cmd/ebpf/xdp/utils/nsh_utils.h
+++ b/cmd/ebpf/xdp/utils/nsh_utils.h
@@ -1,0 +1,59 @@
+#include <linux/bpf.h>
+#include <linux/if_ether.h>
+
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_endian.h>
+
+#define ETH_P_IP 0x0800 /* Internet Protocol packet */
+#define ETH_P_NSH	0x894F /* Network Service Header */
+
+#include "xdp/utils/nsh.h"
+#include "xdp/utils/packet_context.h"
+#include "xdp/utils/trace.h"
+
+// TODO: support metadata
+static __always_inline __u32 add_nsh_over_ip4_headers(struct packet_context *ctx, __u32 path_hdr) {
+
+    static const size_t nsh_encap_size =  NSH_BASE_HDR_LEN; // Without metadata
+
+
+    int result = bpf_xdp_adjust_head(ctx->xdp_ctx, (__s32)-nsh_encap_size);
+    if (result)
+        return -1;
+
+    char *data = (char *)(long)ctx->xdp_ctx->data;
+    char *data_end = (char *)(long)ctx->xdp_ctx->data_end;
+
+    struct ethhdr *orig_eth = (struct ethhdr *)(data + nsh_encap_size);
+    if ((const char *)(orig_eth + 1) > data_end)
+        return -1;
+
+    struct ethhdr *eth = (struct ethhdr *)data;
+    __builtin_memcpy(eth, orig_eth, sizeof(*eth));
+    eth->h_proto = bpf_htons(ETH_P_NSH);
+
+    // /* Add the NSH header */
+    struct nshhdr *nsh = (struct nshhdr *)(eth + 1);
+    if ((const char *)(nsh + 1) > data_end)
+        return -1;
+
+    nsh->ver_flags_ttl_len = 0;
+    nsh->mdtype          = NSH_M_TYPE2;
+    nsh->np              = 0x01;
+    nsh->path_hdr             = bpf_htonl(path_hdr);
+    nsh_set_flags_ttl_len(nsh, 0x0, 0x3F, nsh_encap_size);
+
+    upf_printk("upf: added nsh encap");
+
+    struct iphdr *ip = (struct iphdr *)((char *)nsh + nsh_encap_size);
+    if ((const char *)(ip + 1) > data_end)
+        return -1;
+
+    context_set_ip4(ctx, (char *)(long)ctx->xdp_ctx->data, (const char *)(long)ctx->xdp_ctx->data_end, eth, ip, 0, 0, nsh);
+    return 0;
+}
+
+static __always_inline long remove_nsh_header(struct packet_context *ctx) {
+    return 0;
+}
+

--- a/cmd/ebpf/xdp/utils/packet_context.h
+++ b/cmd/ebpf/xdp/utils/packet_context.h
@@ -23,6 +23,7 @@
 #include <linux/udp.h>
 #include <linux/tcp.h>
 #include "xdp/utils/gtpu.h"
+#include "xdp/utils/nsh.h"
 
 /* Header cursor to keep track of current parsing position */
 struct packet_context {
@@ -37,4 +38,5 @@ struct packet_context {
     struct udphdr *udp;
     struct tcphdr *tcp;
     struct gtpuhdr *gtp;
+    struct nshhdr *nsh;
 };

--- a/cmd/ebpf/xdp/utils/parsers.h
+++ b/cmd/ebpf/xdp/utils/parsers.h
@@ -132,7 +132,7 @@ static __always_inline void swap_ip(struct iphdr *iph) {
     // ip->check = ipv4_csum(ip, sizeof(*ip));
 }
 
-static __always_inline void context_set_ip4(struct packet_context *ctx, char *data, const char *data_end, struct ethhdr *eth, struct iphdr *ip4, struct udphdr *udp, struct gtpuhdr *gtp) {
+static __always_inline void context_set_ip4(struct packet_context *ctx, char *data, const char *data_end, struct ethhdr *eth, struct iphdr *ip4, struct udphdr *udp, struct gtpuhdr *gtp, struct nshhdr *nsh) {
     ctx->data = data;
     ctx->data_end = data_end;
     ctx->eth = eth;
@@ -140,6 +140,7 @@ static __always_inline void context_set_ip4(struct packet_context *ctx, char *da
     ctx->ip6 = 0;
     ctx->udp = udp;
     ctx->gtp = gtp;
+    ctx->nsh = nsh;
 }
 
 static __always_inline void context_reset(struct packet_context *ctx, char *data, const char *data_end) {
@@ -150,6 +151,7 @@ static __always_inline void context_reset(struct packet_context *ctx, char *data
     ctx->ip6 = 0;
     ctx->udp = 0;
     ctx->gtp = 0;
+    ctx->nsh = 0;
 }
 
 


### PR DESCRIPTION
Firstly, thank you for this project!

This pull request introduces support for Traffic Steering within the Service Function Chaining (SFC) framework. This enables the User Plane Function (UPF) to:

- Receive and process forwarding policy information for SFC traffic.
- Apply Network Service Header (NSH) encapsulation to packets based on the received policy.

The traffic steering implementation enables the N6-LAN for perform Service Function Chaining on the traffic after it leaves the UPF but before the internet. Checkout the [OpenN6LAN](https://github.com/tariromukute/OpenN6LAN) project.

Key Changes:

1. Modifications to the UPF to handle forwarding policies in the FAR.
2. Implementation of NSH encapsulation logic within the UPF based on the presence of forwarding policy identifiers.
3. Updates to handle NSH headers during packet processing

Testing:

The changes can be tested by setting up the eUPF and installing FAR rules with forwarding policy identifiers. Please see below. The setup is depicted below, along with the files for setting up the environment for test.

![representation_diagram](https://github.com/edgecomllc/eupf/assets/18515926/4f099251-e11b-47cc-863c-8d964601c69a)



1. Sessions rules to install on eUPF using [pfcp-kitchen-sink](https://github.com/infinitydon/pfcp-kitchen-sink), `sessions-eupf.yaml` in the docker compose below
```yaml
- seid: 0
  pdrs:
  - pdrID: 0
    precedence: 0
    pdi:
      sourceInterface: Access
      networkInstance: access.oai.org
      localFTEID:
        teid: 1234
        ip4: 192.168.71.134
      ueIPAddress:
        isDestination: false
        ip4: 12.1.1.2
    outerHeaderRemoval: OUTER_HEADER_GTPU_UDP_IPV4
    farID: 12
  - pdrID: 1
    precedence: 0
    pdi:
      sourceInterface: SGiLAN
      networkInstance: core.oai.org
      ueIPAddress:
        isDestination: true
        ip4: 12.1.1.2
    farID: 13
  fars:
  - farID: 12
    applyAction: Forward
    forwardingParameters:
      destinationInterface: SGiLAN
      networkInstance: core.oai.org
  - farID: 13
    applyAction: Forward
    forwardingParameters:
      destinationInterface: Access
      networkInstance: access.oai.org
      outerHeaderCreation:
        desc: OUTER_HEADER_CREATION_GTPU_UDP_IPV4
        teid: 1234
        ip: 192.168.71.130
- seid: 1
  pdrs:
  - pdrID: 2
    precedence: 0
    pdi:
      sourceInterface: Access
      networkInstance: access.oai.org
      localFTEID:
        teid: 1235
        ip4: 192.168.71.134
      ueIPAddress:
        isDestination: false
        ip4: 12.1.1.3
    outerHeaderRemoval: OUTER_HEADER_GTPU_UDP_IPV4
    farID: 14
  - pdrID: 3
    precedence: 0
    pdi:
      sourceInterface: SGiLAN
      networkInstance: core.oai.org
      ueIPAddress:
        isDestination: true
        ip4: 12.1.1.3
    farID: 15
  fars:
  - farID: 14
    applyAction: Forward
    forwardingParameters:
      destinationInterface: SGiLAN
      networkInstance: core.oai.org
      forwardingPolicy: 000000000000000000000000000000000000000000011223F
  - farID: 15
    applyAction: Forward
    forwardingParameters:
      destinationInterface: Access
      networkInstance: access.oai.org
      outerHeaderCreation:
        desc: OUTER_HEADER_CREATION_GTPU_UDP_IPV4
        teid: 1235
        ip: 192.168.71.130
```

2. Docker compose for setting up components for testing
```yaml
version: '3.8'
services:
    pfcp-kitchen-sink:
        container_name: "pfcp-kitchen-sink"
        image: tariromukute/pfcp-kitchen-sink:latest
        volumes:
            - ./sessions-eupf.yaml:/app/sessions.yaml
        command: ./pfcpclient -r 192.168.70.134:8805 -s sessions.yaml
        depends_on:
            - edgecomllc-eupf
        networks:
            n4_net:
                ipv4_address: 192.168.70.131
    ue-sim:
        privileged: true # So it can create UE namespaces
        container_name: "ue-sim"
        image: tariromukute/tc-gtpu:latest
        command:
        - /bin/bash
        - -c
        - |
            apt update -y;
            apt install curl -y;

            mkdir -p /etc/netns/uegtp0/
            echo 'nameserver 8.8.8.8' > /etc/netns/uegtp0/resolv.conf
            mkdir -p /etc/netns/uegtp1/
            echo 'nameserver 8.8.8.8' > /etc/netns/uegtp1/resolv.conf

            ./tc-gtpu -g eth0 -i uegtp -s 192.168.71.130 -d 192.168.71.134 \
            -u 12.1.1.2 -b 12.1.1.1 --ul-teid 1234 --dl-teid 1234 --qfi 9 \
            -n 2 -f /home/tu-gtpu.pcap -vvv
        # healthcheck:
        #     test: ip netns exec uegtp0 ping -c 4 192.168.73.129 || exit 1
        #     interval: 10s
        #     timeout: 5s
        #     retries: 5
        volumes:
            - /sys/kernel/debug/:/sys/kernel/debug/
            - /sys/fs/bpf:/sys/fs/bpf
        devices:
            - /dev/net/tun:/dev/net/tun
        depends_on:
            - edgecomllc-eupf
            - pfcp-kitchen-sink
        networks:
            n3_net:
                ipv4_address: 192.168.71.130

    edgecomllc-eupf:
        platform: linux/amd64
        container_name: "edgecomllc-eupf"
        image: tariromukute/edgecomllc-eupf:sfc-latest
        entrypoint:
        - /bin/sh
        - -c
        - |
            sysctl -w net.ipv4.conf.eth2.send_redirects=0;
            sysctl -w net.ipv4.conf.all.send_redirects=0;
            ip route del default;
            ip route add default via 192.168.72.138 dev eth2 &&
            sh /app/bin/entrypoint.sh
        environment:
            - UPF_INTERFACE_NAME=eth0,eth2
            - UPF_XDP_ATTACH_MODE=generic
            - UPF_API_ADDRESS=:8080
            - UPF_PFCP_ADDRESS=:8805
            - UPF_METRICS_ADDRESS=:9091
            - UPF_PFCP_NODE_ID=192.168.70.134
            - UPF_N3_ADDRESS=192.168.71.134
            - UPF_UEIP_POOL=12.1.1.0/24
            - UPF_LOGGING_LEVEL=debug
        cap_add:
            - NET_ADMIN
            - SYS_ADMIN
            - SYS_RESOURCE # setrlimit
        cap_drop:
            - ALL
        ports:
            - "127.0.0.1:8081:8081"
            - "127.0.0.1:8880:8080"
            - "127.0.0.1:9090:9090"
        sysctls:
            - net.ipv4.conf.all.forwarding=1
        privileged: true
        networks:
            n4_net:
                ipv4_address: 192.168.70.134
            n3_net:
                ipv4_address: 192.168.71.134
            n6_net:
                ipv4_address: 192.168.72.134
                mac_address: 02:42:ac:11:65:43
    n6-lan:
        platform: linux/amd64
        privileged: true
        init: true
        container_name: "n6-lan"
        image: tariromukute/openn6lan-ovs:latest
        command: 
        - /bin/bash
        - -c
        - |
            sh testovs.sh
            # ovs-vsctl add-br brovs1
            ovs-vsctl add-port brovs1 eth1
            ip addr flush dev eth1 && ip addr add 192.168.72.138/26 dev brovs1 && ip link set brovs1 up
            ip route add 12.1.1.0/24 via 192.168.72.134 dev brovs1


            ovs-vsctl add-port brovs1 eth0
            ip addr flush dev eth0 && ip addr add 192.168.73.138/26 dev brovs1 && ip link set brovs1 up
            iptables -t nat -A POSTROUTING -o brovs1 -j MASQUERADE

            ip route del default
            ip route add default via 192.168.73.129 dev brovs1

            ip link set dev eth1 xdpgeneric obj /app/nsh-decap.bpf.o sec xdp_nsh_decap

            # Without this setup packets are not forwarded
            sh /app/ovs/install-static-rules.sh
            
            sysctl -w net.ipv4.conf.all.send_redirects=0
            sysctl -w net.ipv4.conf.brovs1.send_redirects=0
            sysctl -w net.ipv4.conf.eth0.send_redirects=0
            sysctl -w net.ipv4.conf.eth1.send_redirects=0

            tail -f /dev/null
        devices:
            - /dev/net/tun:/dev/net/tun # https://docs.openvswitch.org/en/stable/intro/install/userspace/#building-and-installing
        volumes:
            - /lib/modules:/lib/modules
        deploy:
            resources:
                reservations:
                    memory: 2G
        networks:
            n6_net:
                ipv4_address: 192.168.72.138
            data_net:
                ipv4_address: 192.168.73.138

    iperf3:
        privileged: true
        platform: linux/amd64
        container_name: "iperf3"
        image: ubuntu:jammy
        command: 
        - /bin/bash
        - -c
        - |
            apt update -y
            apt install iperf3 -y
            iperf3 -s
        cap_add:
            - NET_ADMIN
        networks:
            data_net:
                ipv4_address: 192.168.73.137

networks:
    n4_net:
        driver: bridge
        name: demo-n4-net
        ipam:
            config:
                - subnet: 192.168.70.128/26
        driver_opts:
            com.docker.network.bridge.name: "demo-n4"
    n3_net:
        driver: bridge
        name: demo-n3-net
        ipam:
            config:
                - subnet: 192.168.71.128/26
        driver_opts:
            com.docker.network.bridge.name: "demo-n3"
    n6_net:
        driver: bridge
        name: demo-n6-net
        ipam:
            config:
                - subnet: 192.168.72.128/26
        driver_opts:
            com.docker.network.bridge.name: "demo-n6"
    data_net:
        driver: bridge
        name: demo-data-net
        ipam:
            config:
                - subnet: 192.168.73.128/26
        driver_opts:
            com.docker.network.bridge.name: "demo-dn"
```

3. Send traffic using the emulated UE. Note: you have to start with the UE without a policy for NSH since the FIB tables need to have been populate prior.

```bash
# UE with ip 12.1.1.2
docker exec -it tc-gtpu \
    ip netns exec uegtp0 ping -c 4 8.8.8.8

# UE with ip 12.1.1.3    
docker exec -it tc-gtpu \
    ip netns exec uegtp1 ping -c 4 8.8.8.8
```