### PR TITLE
fix: deploy commit & image tags for oai-nfapi-sim-compose

### DIFF
--- a/docs/deployments/oai-nfapi-sim-compose/README.md
+++ b/docs/deployments/oai-nfapi-sim-compose/README.md
@@ -1,5 +1,5 @@
 # OpenAir Core + OpenAir RAN as a docker-compose
-We will use 5G L2 nFAPI simulator to test L2 and above Layers. Let's pull Eurecom's deployment for 5G SA mode with 1 User: [OAI Full Stack 5G-NR L2 simulation with containers and a proxy](https://gitlab.eurecom.fr/oai/openairinterface5g/-/tree/develop/ci-scripts/yaml_files/5g_l2sim_tdd) and replace the UPF with our eUPF.
+We will use 5G L2 nFAPI simulator to test L2 and above Layers. Let's pull Eurecom's deployment for 5G SA mode with 1 User: [OAI Full Stack 5G-NR L2 simulation with containers and a proxy](https://gitlab.eurecom.fr/oai/openairinterface5g/-/tree/f1d080d31515d3cc9a31a41fd548753ccba4f09f/ci-scripts/yaml_files/5g_l2sim_tdd) and replace the UPF with our eUPF.
 
 📝This deploy uses `network_mode: "host"` for communications over `lo` interface of the host between containers oai-gnb, proxy, oai-nr-ue0.
 
@@ -7,14 +7,22 @@ We will add two services `edgecom-upf` and `edgecom-nat` with a dedicated networ
 
 ## How to deploy:
 1. Deploy  the whole project "OAI Full Stack 5G-NR L2 simulation with containers and a proxy" 
-    following instructions https://gitlab.eurecom.fr/oai/openairinterface5g/-/blob/develop/ci-scripts/yaml_files/5g_l2sim_tdd/README.md
+    following instructions https://gitlab.eurecom.fr/oai/openairinterface5g/-/blob/f1d080d31515d3cc9a31a41fd548753ccba4f09f/ci-scripts/yaml_files/5g_l2sim_tdd/README.md
+    Use `git checkout f1d080d31515d3cc9a31a41fd548753ccba4f09f` 
 
     <details><summary>TLDR: Look at our example where host interface name is `ens3` with IP addr `188.120.232.247`</summary>
     <p>
 
     ```ruby
-    sergo@edgecom:~/gitlab$ git clone https://gitlab.eurecom.fr/oai/openairinterface5g.git
-    sergo@edgecom:~/gitlab$ cd openairinterface5g/ci-scripts/yaml_files/5g_l2sim_tdd/
+    sergo@edgecom:~/gitlab$ git clone -n https://gitlab.eurecom.fr/oai/openairinterface5g.git
+    sergo@edgecom:~/gitlab$ cd openairinterface5g/
+    sergo@edgecom:~/gitlab/openairinterface5g$ git checkout f1d080d31515d3cc9a31a41fd548753ccba4f09f
+        Note: switching to 'f1d080d31515d3cc9a31a41fd548753ccba4f09f'.
+        ...
+        HEAD is now at f1d080d315 chore(ci): updating 5G rfsimulator scenarios to release v2.0
+
+
+    cd ci-scripts/yaml_files/5g_l2sim_tdd/
 
     nano docker-compose.yaml
                 - DEFAULT_DNS_IPV4_ADDRESS=169.254.25.10  #172.21.3.100

--- a/docs/deployments/oai-nfapi-sim-compose/docker-compose.override.yml
+++ b/docs/deployments/oai-nfapi-sim-compose/docker-compose.override.yml
@@ -28,9 +28,13 @@ services:
       - USE_FQDN_DNS=no
 
   oai-gnb:
+    image: oaisoftwarealliance/oai-gnb:2023.w43
     depends_on: !reset
       - edgecom-upf
       - oai-amf
+
+  oai-nr-ue0:
+    image: oaisoftwarealliance/oai-nr-ue:2023.w43
 
   edgecom-upf:
     container_name: eupf
@@ -106,7 +110,7 @@ services:
     ports:
       - "8081:80"
     environment:
-      - API_PORT=8080
+      - API_PORT=8880
 
 networks:
   privnet_n6:
@@ -116,3 +120,7 @@ networks:
         - subnet: 10.100.250.0/24
     driver_opts:
       com.docker.network.bridge.name: br-oainfapi-n6
+
+volumes:
+  prom_data:
+  

--- a/docs/deployments/oai-nfapi-sim-compose/nat/busy-poll.sh
+++ b/docs/deployments/oai-nfapi-sim-compose/nat/busy-poll.sh
@@ -1,5 +1,5 @@
-#!/bin/bash 
-
+#!/bin/sh 
+set -x 
 terminate=0
 #_term() { 
 #  echo "Caught SIGTERM signal!" 
@@ -19,8 +19,9 @@ iptables -A FORWARD -j ACCEPT
 #ip route add 10.60.0.0/16 via `nslookup upf.free5gc.org | awk '/^Address: / { print $2 }'` dev eth0
 ip route add 10.60.0.0/16 via `nslookup upfn6.free5gc.org | awk '/^Address: / { print $2 }'`
 ip route add 12.1.1.0/24 via `nslookup upfn6.free5gc.org | awk '/^Address: / { print $2 }'`
+ip route show
 
-
+set +x
 while [ $terminate -ne 1 ]
 do
     sleep 10;

--- a/docs/docs-ru_ru/deployments/oai-nfapi-sim-compose/README.md
+++ b/docs/docs-ru_ru/deployments/oai-nfapi-sim-compose/README.md
@@ -1,6 +1,6 @@
 # OpenAir Core + OpenAir RAN as a docker-compose
 
-В данной инструкции используется 5G L2 nFAPI симулятор из проекта OpenAirInterface для эмуляции радиосети и eUPF модуль в качестве замены штатного модуля UPF. Развертывание основано на инструкции Eurecom для 5G SA режиме с 1 абонентом: [OAI Full Stack 5G-NR L2 simulation with containers and a proxy](https://gitlab.eurecom.fr/oai/openairinterface5g/-/tree/develop/ci-scripts/yaml_files/5g_l2sim_tdd), в которой штатный UPF заменен на eUPF.
+В данной инструкции используется 5G L2 nFAPI симулятор из проекта OpenAirInterface для эмуляции радиосети и eUPF модуль в качестве замены штатного модуля UPF. Развертывание основано на инструкции Eurecom для 5G SA режиме с 1 абонентом: [OAI Full Stack 5G-NR L2 simulation with containers and a proxy](https://gitlab.eurecom.fr/oai/openairinterface5g/-/tree/f1d080d31515d3cc9a31a41fd548753ccba4f09f/ci-scripts/yaml_files/5g_l2sim_tdd), в которой штатный UPF заменен на eUPF.
 
 📝В развертывании используется настройка `network_mode: "host"` для того, чтобы обеспечить взаимодействие через `lo` инерфейс хоста между контейнерами oai-gnb, proxy, oai-nr-ue0.
 
@@ -8,14 +8,22 @@
 
 ## Инструкция по развертыванию
 1. Разверните ядро сети и эмулятор радиосети согласно инструкции "OAI Full Stack 5G-NR L2 simulation with containers and a proxy"
-    по ссылке https://gitlab.eurecom.fr/oai/openairinterface5g/-/blob/develop/ci-scripts/yaml_files/5g_l2sim_tdd/README.md
+    по ссылке https://gitlab.eurecom.fr/oai/openairinterface5g/-/blob/f1d080d31515d3cc9a31a41fd548753ccba4f09f/ci-scripts/yaml_files/5g_l2sim_tdd/README.md
+    Переключитесь на `git checkout f1d080d31515d3cc9a31a41fd548753ccba4f09f`
 
     <details><summary>TLDR: Пример команд для хоста с сетевым интерфейсом `ens3` и IP-адресом `188.120.232.247`</summary>
     <p>
 
     ```ruby
-    sergo@edgecom:~/gitlab$ git clone https://gitlab.eurecom.fr/oai/openairinterface5g.git
-    sergo@edgecom:~/gitlab$ cd openairinterface5g/ci-scripts/yaml_files/5g_l2sim_tdd/
+    sergo@edgecom:~/gitlab$ git clone -n https://gitlab.eurecom.fr/oai/openairinterface5g.git
+    sergo@edgecom:~/gitlab$ cd openairinterface5g/
+    sergo@edgecom:~/gitlab/openairinterface5g$ git checkout f1d080d31515d3cc9a31a41fd548753ccba4f09f
+        Note: switching to 'f1d080d31515d3cc9a31a41fd548753ccba4f09f'.
+        ...
+        HEAD is now at f1d080d315 chore(ci): updating 5G rfsimulator scenarios to release v2.0
+
+
+    cd ci-scripts/yaml_files/5g_l2sim_tdd/
 
     nano docker-compose.yaml
                 - DEFAULT_DNS_IPV4_ADDRESS=169.254.25.10  #172.21.3.100


### PR DESCRIPTION
Use images oaisoftwarealliance/oai-gnb:2023.w43  and oaisoftwarealliance/oai-nr-ue:2023.w43 with relevant commit of docker-compose.yaml.