### PR TITLE
fix: use 1.22.4 golang version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-bullseye as builder
+FROM golang:1.22.4-bullseye as builder
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/edgecomllc/eupf
 
-go 1.21
+go 1.22.0
 
 require (
 	github.com/RoaringBitmap/roaring v1.7.0


### PR DESCRIPTION
Bump golang to fix cve-2023-45288: net/http, x/net/http2: unlimited number of CONTINUATION frames causes DoS https://avd.aquasec.com/nvd/cve-2023-45288    