### PR TITLE
feat: add simple URR support

### DIFF
--- a/cmd/core/session.go
+++ b/cmd/core/session.go
@@ -12,6 +12,7 @@ type Session struct {
 	PDRs       map[uint32]SPDRInfo
 	FARs       map[uint32]SFarInfo
 	QERs       map[uint32]SQerInfo
+	URRs       []uint32
 }
 
 func NewSession(localSEID uint64, remoteSEID uint64) *Session {


### PR DESCRIPTION
At the moment, only the addition of URRID and the return of these URRIDs in the UsageReport field have been implemented.

- Acceptance criteria from https://github.com/edgecomllc/eupf/issues/562:
  - [x] UPF sends Usage Report if it was previously requested by URR in Session Establishment/Modification
  - [x] Exact value of usage is 0, because lack of usage monitoring support on the ebpf side