### PR TITLE
feat: add PFCP URR entities management

### DIFF
--- a/cmd/core/ie_overwrite_test.go
+++ b/cmd/core/ie_overwrite_test.go
@@ -60,6 +60,18 @@ func (mapOps *MapOperationsMock) DeleteQer(internalId uint32) error {
 	return nil
 }
 
+func (mapOps *MapOperationsMock) NewUrr(urrInfo ebpf.UrrInfo) (uint32, error) {
+	return 0, nil
+}
+
+func (mapOps *MapOperationsMock) UpdateUrr(internalId uint32, urrInfo ebpf.UrrInfo) error {
+	return nil
+}
+
+func (mapOps *MapOperationsMock) DeleteUrr(internalId uint32) error {
+	return nil
+}
+
 func TestSessionOverwrite(t *testing.T) {
 
 	mapOps := MapOperationsMock{}

--- a/cmd/core/session.go
+++ b/cmd/core/session.go
@@ -12,6 +12,7 @@ type Session struct {
 	PDRs       map[uint32]SPDRInfo
 	FARs       map[uint32]SFarInfo
 	QERs       map[uint32]SQerInfo
+	URRs       map[uint32]SUrrInfo
 }
 
 func NewSession(localSEID uint64, remoteSEID uint64) *Session {
@@ -21,6 +22,7 @@ func NewSession(localSEID uint64, remoteSEID uint64) *Session {
 		PDRs:       map[uint32]SPDRInfo{},
 		FARs:       map[uint32]SFarInfo{},
 		QERs:       map[uint32]SQerInfo{},
+		URRs:       map[uint32]SUrrInfo{},
 	}
 }
 
@@ -40,6 +42,11 @@ type SFarInfo struct {
 
 type SQerInfo struct {
 	QerInfo  ebpf.QerInfo
+	GlobalId uint32
+}
+
+type SUrrInfo struct {
+	UrrInfo  ebpf.UrrInfo
 	GlobalId uint32
 }
 
@@ -87,6 +94,29 @@ func (s *Session) RemoveQer(id uint32) SQerInfo {
 	sQerInfo := s.QERs[id]
 	delete(s.QERs, id)
 	return sQerInfo
+}
+
+func (s *Session) NewUrr(id uint32, internalId uint32, urrInfo ebpf.UrrInfo) {
+	s.URRs[id] = SUrrInfo{
+		UrrInfo:  urrInfo,
+		GlobalId: internalId,
+	}
+}
+
+func (s *Session) UpdateUrr(id uint32, urrInfo ebpf.UrrInfo) {
+	sUrrInfo := s.URRs[id]
+	sUrrInfo.UrrInfo = urrInfo
+	s.URRs[id] = sUrrInfo
+}
+
+func (s *Session) GetUrr(id uint32) SUrrInfo {
+	return s.URRs[id]
+}
+
+func (s *Session) RemoveUrr(id uint32) SUrrInfo {
+	sUrrInfo := s.URRs[id]
+	delete(s.URRs, id)
+	return sUrrInfo
 }
 
 func (s *Session) PutPDR(id uint32, info SPDRInfo) {

--- a/cmd/ebpf/pdr.go
+++ b/cmd/ebpf/pdr.go
@@ -18,6 +18,7 @@ type PdrInfo struct {
 	OuterHeaderRemoval uint8
 	FarId              uint32
 	QerId              uint32
+	UrrId              uint32
 	SdfFilter          *SdfFilter
 }
 
@@ -223,6 +224,27 @@ func (bpfObjects *BpfObjects) DeleteQer(internalId uint32) error {
 	return bpfObjects.QerMap.Update(internalId, unsafe.Pointer(&QerInfo{}), ebpf.UpdateExist)
 }
 
+// TODO: add required fields and implement methods
+type UrrInfo struct {
+	// URRID, MeasurementMethod, TotalVolume?
+}
+
+func (bpfObjects *BpfObjects) NewUrr(urrInfo UrrInfo) (uint32, error) {
+	internalId := uint32(666)
+	log.Debug().Msgf("EBPF: Put URR: internalId=%d, urrInfo=%+v", internalId, urrInfo)
+	return internalId, nil
+}
+
+func (bpfObjects *BpfObjects) UpdateUrr(internalId uint32, urrInfo UrrInfo) error {
+	log.Debug().Msgf("EBPF: Update URR: internalId=%d, urrInfo=%+v", internalId, urrInfo)
+	return nil
+}
+
+func (bpfObjects *BpfObjects) DeleteUrr(internalId uint32) error {
+	log.Debug().Msgf("EBPF: Delete URR: internalId=%d", internalId)
+	return nil
+}
+
 type ForwardingPlaneController interface {
 	PutPdrUplink(teid uint32, pdrInfo PdrInfo) error
 	PutPdrDownlink(ipv4 net.IP, pdrInfo PdrInfo) error
@@ -239,6 +261,9 @@ type ForwardingPlaneController interface {
 	NewQer(qerInfo QerInfo) (uint32, error)
 	UpdateQer(internalId uint32, qerInfo QerInfo) error
 	DeleteQer(internalId uint32) error
+	NewUrr(urrInfo UrrInfo) (uint32, error)
+	UpdateUrr(internalId uint32, urrInfo UrrInfo) error
+	DeleteUrr(internalId uint32) error
 }
 
 func CombinePdrWithSdf(defaultPdr *IpEntrypointPdrInfo, sdfPdr PdrInfo) IpEntrypointPdrInfo {


### PR DESCRIPTION
-  This PR includes all changes from https://github.com/edgecomllc/eupf/pull/567 and adds the following improvements:
    - [x] eUPF handle CreateURR IE and saves corresponding data for PFCP session
    - [x] eUPF handle UpdateURR IE, verifies that such URR has been created previously and updates it params
    - [x] eUPF handle RemoveURR IE, verifies that such URR has been created previously and deletes it
    - [x] eUPF sends reports at least during session deletion according to currently installed URRs