### PR TITLE
refactor(pfcp): Improve logging and error handling during session create/modify/delete

### DIFF
--- a/cmd/core/pdr.go
+++ b/cmd/core/pdr.go
@@ -10,20 +10,24 @@ import (
 
 const flagPresentIPv4 = 2
 
-func applyPDR(spdrInfo SPDRInfo, mapOperations ebpf.ForwardingPlaneController) {
+func applyPDR(spdrInfo SPDRInfo, mapOperations ebpf.ForwardingPlaneController) error {
 	if spdrInfo.Ipv4 != nil {
 		if err := mapOperations.PutPdrDownlink(spdrInfo.Ipv4, spdrInfo.PdrInfo); err != nil {
-			log.Info().Msgf("Can't apply IPv4 PDR: %s", err.Error())
+			log.Error().Err(err).Msg("Can't apply IPv4 PDR")
+			return err
 		}
 	} else if spdrInfo.Ipv6 != nil {
 		if err := mapOperations.PutDownlinkPdrIp6(spdrInfo.Ipv6, spdrInfo.PdrInfo); err != nil {
-			log.Info().Msgf("Can't apply IPv6 PDR: %s", err.Error())
+			log.Error().Err(err).Msg("Can't apply IPv6 PDR")
+			return err
 		}
 	} else {
 		if err := mapOperations.PutPdrUplink(spdrInfo.Teid, spdrInfo.PdrInfo); err != nil {
-			log.Info().Msgf("Can't apply GTP PDR: %s", err.Error())
+			log.Error().Err(err).Msg("Can't apply GTP PDR")
+			return err
 		}
 	}
+	return nil
 }
 
 func processCreatedPDRs(createdPDRs []SPDRInfo, n3Address net.IP) []*ie.IE {

--- a/cmd/core/pfcp_session_handlers_test.go
+++ b/cmd/core/pfcp_session_handlers_test.go
@@ -552,12 +552,17 @@ func TestUEIPInAssociationSetupResponse(t *testing.T) {
 
 func TestHandlePfcpSessionEstablishmentRequestWithURR(t *testing.T) {
 	pfcpConn, smfIP := PreparePfcpConnection(t)
+	ip1, _ := net.ResolveIPAddr("ip", "1.1.1.1")
 
 	estReq := message.NewSessionEstablishmentRequest(0, 0, 2, 1, 0,
 		ie.NewNodeID("", "", "test"),
 		ie.NewFSEID(1, net.ParseIP(smfIP), nil),
 		ie.NewCreatePDR(
 			ie.NewPDRID(0xffff),
+			ie.NewPDI(
+				ie.NewSourceInterface(ie.SrcInterfaceCore),
+				ie.NewFTEID(0, 0, ip1.IP, nil, 0),
+			),
 		),
 		ie.NewCreateURR(
 			ie.NewURRID(0xf),
@@ -576,12 +581,17 @@ func TestHandlePfcpSessionEstablishmentRequestWithURR(t *testing.T) {
 func TestHandlePfcpSessionModificationRequestWithURR(t *testing.T) {
 	ebpfMock := &MapOperationsMock{}
 	pfcpConn, smfIP := PreparePfcpConnectionWithMock(t, ebpfMock)
+	ip1, _ := net.ResolveIPAddr("ip", "1.1.1.1")
 
 	estReq := message.NewSessionEstablishmentRequest(0, 0, 2, 1, 0,
 		ie.NewNodeID("", "", "test"),
 		ie.NewFSEID(1, net.ParseIP(smfIP), nil),
 		ie.NewCreatePDR(
 			ie.NewPDRID(0xffff),
+			ie.NewPDI(
+				ie.NewSourceInterface(ie.SrcInterfaceCore),
+				ie.NewFTEID(0, 0, ip1.IP, nil, 0),
+			),
 		),
 	)
 	_, err := HandlePfcpSessionEstablishmentRequest(&pfcpConn, estReq, smfIP)
@@ -676,12 +686,17 @@ func TestHandlePfcpSessionDeletionRequestWithURR(t *testing.T) {
 
 	ebpfMock := &MapOperationsMock{}
 	pfcpConn, smfIP := PreparePfcpConnectionWithMock(t, ebpfMock)
+	ip1, _ := net.ResolveIPAddr("ip", "1.1.1.1")
 
 	estReq := message.NewSessionEstablishmentRequest(0, 0, 2, 1, 0,
 		ie.NewNodeID("", "", "test"),
 		ie.NewFSEID(1, net.ParseIP(smfIP), nil),
 		ie.NewCreatePDR(
 			ie.NewPDRID(0xffff),
+			ie.NewPDI(
+				ie.NewSourceInterface(ie.SrcInterfaceCore),
+				ie.NewFTEID(0, 0, ip1.IP, nil, 0),
+			),
 		),
 		ie.NewCreateURR(
 			ie.NewURRID(0xf),


### PR DESCRIPTION
Before this patch, eupf would silently (info log level) skip PDR creation failures due to map sizes being too small, accepting the the PFCP session creation request.
This patch makes sure:
* The issue is reported at a meaningful log level (warn or error)
* The PFCP session creation request is rejectedt