### PR TITLE
refactor(xdp): rename GTPU[IPv4+TEID]->PDR map

### DIFF
--- a/cmd/api/rest/uplink_pdr.go
+++ b/cmd/api/rest/uplink_pdr.go
@@ -26,7 +26,7 @@ func (h *ApiHandler) getUplinkPdrValue(c *gin.Context) {
 	}
 
 	var value ebpf.PdrInfo
-	if err = h.BpfObjects.IpEntrypointObjects.PdrMapUplinkIp4.Lookup(uint32(id), unsafe.Pointer(&value)); err != nil {
+	if err = h.BpfObjects.IpEntrypointObjects.PdrMapTeidIp4.Lookup(uint32(id), unsafe.Pointer(&value)); err != nil {
 		log.Printf("Error reading map: %s", err.Error())
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
@@ -55,7 +55,7 @@ func (h *ApiHandler) setUplinkPdrValue(c *gin.Context) {
 		QerId:              pdrElement.QerId,
 	}
 
-	if err := h.BpfObjects.IpEntrypointObjects.PdrMapUplinkIp4.Put(uint32(pdrElement.Id), unsafe.Pointer(&value)); err != nil {
+	if err := h.BpfObjects.IpEntrypointObjects.PdrMapTeidIp4.Put(uint32(pdrElement.Id), unsafe.Pointer(&value)); err != nil {
 		log.Printf("Error writting map: %s", err.Error())
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/cmd/ebpf/objects.go
+++ b/cmd/ebpf/objects.go
@@ -164,7 +164,7 @@ func (bpfObjects *BpfObjects) ResizeAllMaps(qerMapSize uint32, farMapSize uint32
 		log.Info().Msgf("Failed to resize PDR map: %s", err)
 		return err
 	}
-	if err := ResizeEbpfMap(&bpfObjects.PdrMapUplinkIp4, bpfObjects.UpfIpEntrypointFunc, pdrMapSize); err != nil {
+	if err := ResizeEbpfMap(&bpfObjects.PdrMapTeidIp4, bpfObjects.UpfIpEntrypointFunc, pdrMapSize); err != nil {
 		log.Info().Msgf("Failed to resize PDR map: %s", err)
 		return err
 	}

--- a/cmd/ebpf/objects_test.go
+++ b/cmd/ebpf/objects_test.go
@@ -181,7 +181,7 @@ func testGtpWithPDRBenchmark(bpfObjects *BpfObjects, repeat int) (int64, error) 
 	if err := bpfObjects.QerMap.Put(uint32(1), unsafe.Pointer(&qer)); err != nil {
 		return 0, fmt.Errorf("benchmark run failed: %v", err)
 	}
-	if err := bpfObjects.PdrMapUplinkIp4.Put(teid, unsafe.Pointer(&pdr)); err != nil {
+	if err := bpfObjects.PdrMapTeidIp4.Put(teid, unsafe.Pointer(&pdr)); err != nil {
 		return 0, fmt.Errorf("benchmark run failed: %v", err)
 	}
 

--- a/cmd/ebpf/pdr.go
+++ b/cmd/ebpf/pdr.go
@@ -56,13 +56,13 @@ func (bpfObjects *BpfObjects) PutPdrUplink(teid uint32, pdrInfo PdrInfo) error {
 	var pdrToStore IpEntrypointPdrInfo
 	var err error
 	if pdrInfo.SdfFilter != nil {
-		if pdrToStore, err = PreprocessPdrWithSdf(bpfObjects.PdrMapUplinkIp4.Lookup, teid, pdrInfo); err != nil {
+		if pdrToStore, err = PreprocessPdrWithSdf(bpfObjects.PdrMapTeidIp4.Lookup, teid, pdrInfo); err != nil {
 			return err
 		}
 	} else {
 		pdrToStore = ToIpEntrypointPdrInfo(pdrInfo)
 	}
-	return bpfObjects.PdrMapUplinkIp4.Put(teid, unsafe.Pointer(&pdrToStore))
+	return bpfObjects.PdrMapTeidIp4.Put(teid, unsafe.Pointer(&pdrToStore))
 }
 
 func (bpfObjects *BpfObjects) PutPdrDownlink(ipv4 net.IP, pdrInfo PdrInfo) error {
@@ -84,13 +84,13 @@ func (bpfObjects *BpfObjects) UpdatePdrUplink(teid uint32, pdrInfo PdrInfo) erro
 	var pdrToStore IpEntrypointPdrInfo
 	var err error
 	if pdrInfo.SdfFilter != nil {
-		if pdrToStore, err = PreprocessPdrWithSdf(bpfObjects.PdrMapUplinkIp4.Lookup, teid, pdrInfo); err != nil {
+		if pdrToStore, err = PreprocessPdrWithSdf(bpfObjects.PdrMapTeidIp4.Lookup, teid, pdrInfo); err != nil {
 			return err
 		}
 	} else {
 		pdrToStore = ToIpEntrypointPdrInfo(pdrInfo)
 	}
-	return bpfObjects.PdrMapUplinkIp4.Update(teid, unsafe.Pointer(&pdrToStore), ebpf.UpdateExist)
+	return bpfObjects.PdrMapTeidIp4.Update(teid, unsafe.Pointer(&pdrToStore), ebpf.UpdateExist)
 }
 
 func (bpfObjects *BpfObjects) UpdatePdrDownlink(ipv4 net.IP, pdrInfo PdrInfo) error {
@@ -109,7 +109,7 @@ func (bpfObjects *BpfObjects) UpdatePdrDownlink(ipv4 net.IP, pdrInfo PdrInfo) er
 
 func (bpfObjects *BpfObjects) DeletePdrUplink(teid uint32) error {
 	log.Debug().Msgf("EBPF: Delete PDR Uplink: teid=%d", teid)
-	return bpfObjects.PdrMapUplinkIp4.Delete(teid)
+	return bpfObjects.PdrMapTeidIp4.Delete(teid)
 }
 
 func (bpfObjects *BpfObjects) DeletePdrDownlink(ipv4 net.IP) error {

--- a/cmd/ebpf/xdp/n3n6_entrypoint.c
+++ b/cmd/ebpf/xdp/n3n6_entrypoint.c
@@ -192,7 +192,7 @@ static __always_inline enum xdp_action handle_gtp_packet(struct packet_context *
      *   Step 1: search for PDR and apply PDR instructions
      */
     __u32 teid = bpf_htonl(ctx->gtp->teid);
-    struct pdr_info *pdr = bpf_map_lookup_elem(&pdr_map_uplink_ip4, &teid);
+    struct pdr_info *pdr = bpf_map_lookup_elem(&pdr_map_teid_ip4, &teid);
     if (!pdr) {
         upf_printk("upf: [n3] no session for teid:%u", teid);
         return DEFAULT_XDP_ACTION;

--- a/cmd/ebpf/xdp/pdr.h
+++ b/cmd/ebpf/xdp/pdr.h
@@ -22,7 +22,7 @@
 
 #include "xdp/sdf_filter.h"
 
-#define PDR_MAP_UPLINK_SIZE 1024
+#define PDR_MAP_TEID_IPV4_SIZE 1024
 #define PDR_MAP_DOWNLINK_IPV4_SIZE 1024
 #define PDR_MAP_DOWNLINK_IPV6_SIZE 1024
 #define FAR_MAP_SIZE 1024
@@ -89,8 +89,8 @@ struct
     __uint(type, BPF_MAP_TYPE_HASH);
     __type(key, __u32);
     __type(value, struct pdr_info);
-    __uint(max_entries, PDR_MAP_UPLINK_SIZE);
-} pdr_map_uplink_ip4 SEC(".maps");
+    __uint(max_entries, PDR_MAP_TEID_IPV4_SIZE);
+} pdr_map_teid_ip4 SEC(".maps");
 
 enum far_action_mask {
     FAR_DROP = 0x01,


### PR DESCRIPTION
This map is also used for downlink traffic during tunmap operation (N3 interface), hence previous name was misleading and led to setting wrong value on it.