### PR TITLE
fix: ebpf program build warnings

### DIFF
--- a/cmd/ebpf/objects_test.go
+++ b/cmd/ebpf/objects_test.go
@@ -29,10 +29,10 @@ import (
 
 var (
 	n3IP = net.ParseIP("10.3.0.10")
-	n9IP = net.ParseIP("10.3.0.20")
+	//n9IP = net.ParseIP("10.3.0.20")
 
 	n3MAC = net.HardwareAddr{1, 0, 0, 3, 0, 10}
-	n9MAC = net.HardwareAddr{1, 0, 0, 3, 0, 20}
+	//n9MAC = net.HardwareAddr{1, 0, 0, 3, 0, 20}
 )
 
 func testArp(bpfObjects *BpfObjects) error {

--- a/cmd/ebpf/objects_test.go
+++ b/cmd/ebpf/objects_test.go
@@ -27,6 +27,14 @@ import (
 	"github.com/google/gopacket/layers"
 )
 
+var (
+	n3IP = net.ParseIP("10.3.0.10")
+	n9IP = net.ParseIP("10.3.0.20")
+
+	n3MAC = net.HardwareAddr{1, 0, 0, 3, 0, 10}
+	n9MAC = net.HardwareAddr{1, 0, 0, 3, 0, 20}
+)
+
 func testArp(bpfObjects *BpfObjects) error {
 
 	packetArp := gopacket.NewSerializeBuffer()
@@ -559,6 +567,15 @@ func TestEntrypoint(t *testing.T) {
 	}
 
 	defer bpfObjects.Close()
+
+	entrypointConfig := IpEntrypointDataplaneConfig{
+		N3Ipv4Address: binary.LittleEndian.Uint32(n3IP.To4()),
+		N9Ipv4Address: binary.LittleEndian.Uint32(n9IP.To4()),
+	}
+
+	if err := bpfObjects.GlobalConfig.Set(entrypointConfig); err != nil {
+		t.Fatalf("scan't set dataplane global config: %s", err.Error())
+	}
 
 	t.Run("Arp test", func(t *testing.T) {
 		err := testArp(bpfObjects)

--- a/cmd/ebpf/objects_test.go
+++ b/cmd/ebpf/objects_test.go
@@ -29,9 +29,9 @@ import (
 
 var (
 	n3IP = net.ParseIP("10.3.0.10")
-	//n9IP = net.ParseIP("10.3.0.20")
+	n9IP = net.ParseIP("10.3.0.20")
 
-	n3MAC = net.HardwareAddr{1, 0, 0, 3, 0, 10}
+	//n3MAC = net.HardwareAddr{1, 0, 0, 3, 0, 10}
 	//n9MAC = net.HardwareAddr{1, 0, 0, 3, 0, 20}
 )
 

--- a/cmd/ebpf/xdp/qer.h
+++ b/cmd/ebpf/xdp/qer.h
@@ -64,7 +64,7 @@ static __always_inline enum xdp_action limit_rate_simple(struct xdp_md *ctx, __u
     return XDP_DROP;
 }
 
-static __always_inline enum xdp_action limit_rate_sliding_window(const __u64 packet_size, __u64 *windows_start, const __u64 rate) {
+static __always_inline enum xdp_action limit_rate_sliding_window(const __u64 packet_size, volatile __u64 *windows_start, const __u64 rate) {
     static const __u64 NSEC_PER_SEC = 1000000000ULL;
     static const __u64 window_size = 5000000ULL;
 


### PR DESCRIPTION
Use a correct qualifier for function argument in order to fix `-Wincompatible-pointer-types-discards-qualifiers`.

```
/git/eupf/cmd/ebpf/xdp/n3n6_entrypoint.c:114:60: warning: passing 'volatile __u64 *' (aka 'volatile unsigned long long *') to parameter of type '__u64 *' (aka 'unsigned long long *') discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
    if (XDP_DROP == limit_rate_sliding_window(packet_size, &qer->dl_start, qer->dl_maximum_bitrate))
                                                           ^~~~~~~~~~~~~~
./xdp/qer.h:67:98: note: passing argument to parameter 'windows_start' here
static __always_inline enum xdp_action limit_rate_sliding_window(const __u64 packet_size, __u64 *windows_start, const __u64 rate) {
                                                                                                 ^
/git/eupf/cmd/ebpf/xdp/n3n6_entrypoint.c:177:60: warning: passing 'volatile __u64 *' (aka 'volatile unsigned long long *') to parameter of type '__u64 *' (aka 'unsigned long long *') discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
    if (XDP_DROP == limit_rate_sliding_window(packet_size, &qer->dl_start, qer->dl_maximum_bitrate))
                                                           ^~~~~~~~~~~~~~
./xdp/qer.h:67:98: note: passing argument to parameter 'windows_start' here
static __always_inline enum xdp_action limit_rate_sliding_window(const __u64 packet_size, __u64 *windows_start, const __u64 rate) {
                                                                                                 ^
/git/eupf/cmd/ebpf/xdp/n3n6_entrypoint.c:309:60: warning: passing 'volatile __u64 *' (aka 'volatile unsigned long long *') to parameter of type '__u64 *' (aka 'unsigned long long *') discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
    if (XDP_DROP == limit_rate_sliding_window(packet_size, &qer->ul_start, qer->ul_maximum_bitrate))
                                                           ^~~~~~~~~~~~~~
./xdp/qer.h:67:98: note: passing argument to parameter 'windows_start' here
static __always_inline enum xdp_action limit_rate_sliding_window(const __u64 packet_size, __u64 *windows_start, const __u64 rate) {
                                                                                                 ^
3 warnings generated.
```