### PR TITLE
chore: use global config for local ip

### DIFF
--- a/cmd/api/rest/far_map.go
+++ b/cmd/api/rest/far_map.go
@@ -16,7 +16,6 @@ type FarMapElement struct {
 	OuterHeaderCreation   uint8  `json:"outer_header_creation"`
 	Teid                  uint32 `json:"teid"`
 	RemoteIP              uint32 `json:"remote_ip"`
-	LocalIP               uint32 `json:"local_ip"`
 	TransportLevelMarking uint16 `json:"transport_level_marking"`
 }
 
@@ -41,7 +40,6 @@ func (h *ApiHandler) getFarValue(c *gin.Context) {
 		OuterHeaderCreation:   value.OuterHeaderCreation,
 		Teid:                  value.Teid,
 		RemoteIP:              value.RemoteIP,
-		LocalIP:               value.LocalIP,
 		TransportLevelMarking: value.TransportLevelMarking,
 	})
 }
@@ -59,7 +57,6 @@ func (h *ApiHandler) setFarValue(c *gin.Context) {
 		OuterHeaderCreation:   farElement.OuterHeaderCreation,
 		Teid:                  farElement.Teid,
 		RemoteIP:              farElement.RemoteIP,
-		LocalIP:               farElement.LocalIP,
 		TransportLevelMarking: farElement.TransportLevelMarking,
 	}
 

--- a/cmd/ebpf/objects_test.go
+++ b/cmd/ebpf/objects_test.go
@@ -172,7 +172,7 @@ func testGtpWithPDRBenchmark(bpfObjects *BpfObjects, repeat int) (int64, error) 
 	}
 
 	pdr := PdrInfo{OuterHeaderRemoval: 0, FarId: 1, QerId: 1}
-	far := FarInfo{Action: 2, OuterHeaderCreation: 1, RemoteIP: 1, LocalIP: 2, Teid: 2, TransportLevelMarking: 0}
+	far := FarInfo{Action: 2, OuterHeaderCreation: 1, RemoteIP: 1, Teid: 2, TransportLevelMarking: 0}
 	qer := QerInfo{GateStatusUL: 0, GateStatusDL: 0, Qfi: 0, MaxBitrateUL: 1000000, MaxBitrateDL: 100000, StartUL: 0, StartDL: 0}
 
 	if err := bpfObjects.FarMap.Put(uint32(1), unsafe.Pointer(&far)); err != nil {
@@ -303,8 +303,8 @@ func testGtpWithSDFFilter(bpfObjects *BpfObjects) error {
 	}
 
 	pdr := PdrInfo{OuterHeaderRemoval: 0, FarId: 1, QerId: 1}
-	farForward := FarInfo{Action: 2, OuterHeaderCreation: 1, RemoteIP: 1, LocalIP: 2, Teid: 2, TransportLevelMarking: 0}
-	farDrop := FarInfo{Action: 1, OuterHeaderCreation: 1, RemoteIP: 1, LocalIP: 2, Teid: 2, TransportLevelMarking: 0}
+	farForward := FarInfo{Action: 2, OuterHeaderCreation: 1, RemoteIP: 1, Teid: 2, TransportLevelMarking: 0}
+	farDrop := FarInfo{Action: 1, OuterHeaderCreation: 1, RemoteIP: 1, Teid: 2, TransportLevelMarking: 0}
 	qer := QerInfo{GateStatusUL: 0, GateStatusDL: 0, Qfi: 0, MaxBitrateUL: 1000000, MaxBitrateDL: 100000, StartUL: 0, StartDL: 0}
 
 	if err := bpfObjects.FarMap.Put(uint32(1), unsafe.Pointer(&farForward)); err != nil {
@@ -381,7 +381,6 @@ func testGtpExtHeader(t *testing.T, bpfObjects *BpfObjects) error {
 		Action:                2,
 		OuterHeaderCreation:   1,
 		RemoteIP:              binary.LittleEndian.Uint32(net.IP{10, 3, 0, 10}),
-		LocalIP:               binary.LittleEndian.Uint32(net.IP{10, 3, 0, 20}),
 		Teid:                  teid,
 		TransportLevelMarking: 0}
 	qer := QerInfo{GateStatusUL: 0, GateStatusDL: 0, Qfi: 5, MaxBitrateUL: 1000000, MaxBitrateDL: 100000, StartUL: 0, StartDL: 0}
@@ -484,7 +483,6 @@ func testDLwithGTPPort(t *testing.T, bpfObjects *BpfObjects) error {
 		Action:                2,
 		OuterHeaderCreation:   1,
 		RemoteIP:              binary.LittleEndian.Uint32(net.IP{10, 3, 0, 10}),
-		LocalIP:               binary.LittleEndian.Uint32(net.IP{10, 3, 0, 20}),
 		Teid:                  teid,
 		TransportLevelMarking: 0}
 	qer := QerInfo{GateStatusUL: 0, GateStatusDL: 0, Qfi: 5, MaxBitrateUL: 1000000, MaxBitrateDL: 100000, StartUL: 0, StartDL: 0}

--- a/cmd/ebpf/pdr.go
+++ b/cmd/ebpf/pdr.go
@@ -155,21 +155,17 @@ type FarInfo struct {
 	OuterHeaderCreation   uint8
 	Teid                  uint32
 	RemoteIP              uint32
-	LocalIP               uint32
 	TransportLevelMarking uint16
 }
 
 func (f FarInfo) MarshalJSON() ([]byte, error) {
 	remoteIP := make(net.IP, 4)
-	localIP := make(net.IP, 4)
 	binary.LittleEndian.PutUint32(remoteIP, f.RemoteIP)
-	binary.LittleEndian.PutUint32(localIP, f.LocalIP)
 	data := map[string]interface{}{
 		"action":                  f.Action,
 		"outer_header_creation":   f.OuterHeaderCreation,
 		"teid":                    f.Teid,
 		"remote_ip":               remoteIP.String(),
-		"local_ip":                localIP.String(),
 		"transport_level_marking": f.TransportLevelMarking,
 	}
 	return json.Marshal(data)

--- a/cmd/ebpf/xdp/pdr.h
+++ b/cmd/ebpf/xdp/pdr.h
@@ -115,7 +115,6 @@ struct far_info {
     __u8 outer_header_creation;
     __u32 teid;
     __u32 remoteip;
-    __u32 localip;
     /* first octet DSCP value in the Type-of-Service, second octet shall contain the ToS/Traffic Class mask field, which shall be set to "0xFC". */
     __u16 transport_level_marking;
 };

--- a/docs/install.md
+++ b/docs/install.md
@@ -324,10 +324,10 @@ Session Establishment Request:
     Max Bitrate UL: 200000
     QFI: 9
 2023/04/17 16:11:50 WARN: No OuterHeaderCreation
-2023/04/17 16:11:50 Saving FAR info to session: 1, {Action:2 OuterHeaderCreation:0 Teid:0 RemoteIP:0 LocalIP:0}
-2023/04/17 16:11:50 EBPF: Put FAR: i=1, farInfo={Action:2 OuterHeaderCreation:0 Teid:0 RemoteIP:0 LocalIP:0}
-2023/04/17 16:11:50 Saving FAR info to session: 2, {Action:2 OuterHeaderCreation:0 Teid:0 RemoteIP:0 LocalIP:0}
-2023/04/17 16:11:50 EBPF: Put FAR: i=2, farInfo={Action:2 OuterHeaderCreation:0 Teid:0 RemoteIP:0 LocalIP:0}
+2023/04/17 16:11:50 Saving FAR info to session: 1, {Action:2 OuterHeaderCreation:0 Teid:0 RemoteIP:0}
+2023/04/17 16:11:50 EBPF: Put FAR: i=1, farInfo={Action:2 OuterHeaderCreation:0 Teid:0 RemoteIP:0}
+2023/04/17 16:11:50 Saving FAR info to session: 2, {Action:2 OuterHeaderCreation:0 Teid:0 RemoteIP:0}
+2023/04/17 16:11:50 EBPF: Put FAR: i=2, farInfo={Action:2 OuterHeaderCreation:0 Teid:0 RemoteIP:0}
 2023/04/17 16:11:50 Saving uplink PDR info to session: 1, {PdrInfo:{OuterHeaderRemoval:0 FarId:1} Teid:1 Ipv4:<nil>}
 2023/04/17 16:11:50 EBPF: Put PDR Uplink: teid=1, pdrInfo={OuterHeaderRemoval:0 FarId:1}
 2023/04/17 16:11:50 Saving downlink PDR info to session: 2, {PdrInfo:{OuterHeaderRemoval:0 FarId:2} Teid:0 Ipv4:10.1.0.1}
@@ -349,8 +349,8 @@ Session Modification Request:
   UpdateFAR ID: 2
     Apply Action: [2]
     Forwarding Parameters:
-2023/04/17 16:11:50 Updating FAR info: 2, {Action:2 OuterHeaderCreation:1 Teid:2 RemoteIP:3962725386 LocalIP:0}
-2023/04/17 16:11:50 EBPF: Update FAR: i=2, farInfo={Action:2 OuterHeaderCreation:1 Teid:2 RemoteIP:3962725386 LocalIP:0}
+2023/04/17 16:11:50 Updating FAR info: 2, {Action:2 OuterHeaderCreation:1 Teid:2 RemoteIP:3962725386}
+2023/04/17 16:11:50 EBPF: Update FAR: i=2, farInfo={Action:2 OuterHeaderCreation:1 Teid:2 RemoteIP:3962725386}
 2023/04/17 16:11:50 Updating downlink PDR: 2, {PdrInfo:{OuterHeaderRemoval:0 FarId:2} Teid:0 Ipv4:10.1.0.1}
 2023/04/17 16:11:50 EBPF: Update PDR Downlink: ipv4=10.1.0.1, pdrInfo={OuterHeaderRemoval:0 FarId:2}
 Stream closed EOF for free5gc/edgecomllc-eupf-universal-chart-d4b54d4b7-t2hr6 (app)
@@ -626,15 +626,13 @@ writing to stdout
                         "Action": 2,
                         "OuterHeaderCreation": 0,
                         "Teid": 0,
-                        "RemoteIP": 0,
-                        "LocalIP": 0
+                        "RemoteIP": 0
                     },
                     "2": {
                         "Action": 2,
                         "OuterHeaderCreation": 1,
                         "Teid": 3,
-                        "RemoteIP": 3962725386,
-                        "LocalIP": 3912393738
+                        "RemoteIP": 3962725386
                     }
                 },
                 "QERs": {


### PR DESCRIPTION
Use ebpf settings value for local ip(N3 and N9) instead of passing local ip in FAR via ebps maps.